### PR TITLE
fix: 端口统一3000 + 清理karen域名配置

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -18,7 +18,7 @@ import segRoute from './routes/segRoute.js';
 dotenv.config();
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 3000;
 
 // parse incoming data
 // send image/price/etc., extract json data
@@ -26,8 +26,8 @@ app.use(express.json({ limit: '50mb' })); // 增加请求体大小限制
 app.use(express.urlencoded({ limit: '50mb', extended: true }));
 app.use(
   cors({
-    origin: ["http://localhost:5173", "http://localhost:5174", "https://karen.geniuscai.com"], // 允许的前端地址
-    credentials: true, // 允许携带cookie
+    origin: ["http://localhost:5173", "http://localhost:5174"],
+    credentials: true,
   })
 ); // enable CORS for all routes
 app.use(morgan('dev')); // log requests to the console

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,10 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: [
-      "karen.geniuscai.com",
-      "localhost",
-      "127.0.0.1"
-    ]
+    allowedHosts: ["localhost", "127.0.0.1"]
   }
 })


### PR DESCRIPTION
## Summary
- 后端端口 3001 → 3000
- 移除 CORS 和 allowedHosts 中的 karen.geniuscai.com

## 关联 Issues
Closes #19, #20